### PR TITLE
Coma voxel emission rendering for the opengl rendering path

### DIFF
--- a/data/input/oneshot_67p_opengl.json
+++ b/data/input/oneshot_67p_opengl.json
@@ -60,13 +60,13 @@
             },
             "model":
             {
-                "file": "data/models/67p+tex-16k.obj",
+                "file": "data/models/67P_C-G_shape_model_MALMER_2015_11_20-in-km.obj",
                 "name": "67P"
             },
             "coma":
             {
                 "file": "data/models/Jets--ROS_CAM1_20150710T074301.json",
-                "intensity": 1e-4
+                "intensity": 2e-6
             },
             "max_dim": 512,
             "brdf_params":
@@ -85,8 +85,8 @@
         },
         "instrument": 
         {
-            "res": [1024, 1024],
-            "pix_l": 13.0,
+            "res": [2048, 2048],
+            "pix_l": 6.5,
             "focal_l": 152.5,
             "aperture_d": 30,
             "wavelength": 550.0,

--- a/data/input/oneshot_67p_opengl.json
+++ b/data/input/oneshot_67p_opengl.json
@@ -30,19 +30,6 @@
         "device": "GPU",
         "tile_size": 256,
         "starcat_dir": "data/stardb/deep_space_objects.sqlite",
-        "brdf_params": 
-        {
-			"J": 0,
-			"th_p": 27.07,
-			"w": 0.034,
-			"b": -0.078577,
-			"c": 0,
-			"B_SH0": 2.25,
-			"hs": 0.00106,
-			"B_CB0": 0,
-			"hc": 0.005,
-			"K": 1
-		},
         "sun": null,
         "lightref": null,
 		"spacecraft": {
@@ -73,11 +60,28 @@
             },
             "model":
             {
-                "file": "data/models/67P_C-G_shape_model_MALMER_2015_11_20-in-km.obj",
+                "file": "data/models/67p+tex-16k.obj",
                 "name": "67P"
             },
-            "albedo": 0.15,
-            "max_dim": 512
+            "coma":
+            {
+                "file": "data/models/Jets--ROS_CAM1_20150710T074301.json",
+                "intensity": 1e-4
+            },
+            "max_dim": 512,
+            "brdf_params":
+            {
+                "J": 0,
+                "th_p": 27.07,
+                "w": 0.034,
+                "b": -0.078577,
+                "c": 0,
+                "B_SH0": 2.25,
+                "hs": 0.00106,
+                "B_CB0": 0,
+                "hc": 0.005,
+                "K": 1
+            }
         },
         "instrument": 
         {

--- a/data/input/oneshot_itokawa_opengl.json
+++ b/data/input/oneshot_itokawa_opengl.json
@@ -26,7 +26,7 @@
         "timesampler_mode": 1,
         "slowmotion_factor": 10,
         "exposure": 0,
-        "samples": 4,
+        "samples": 1,
         "device": "GPU",
         "tile_size": 256,
         "starcat_dir": "data/stardb/deep_space_objects.sqlite",
@@ -82,8 +82,8 @@
         },
         "instrument": 
         {
-            "res": [1024, 1024],
-            "pix_l": 12.0,
+            "res": [8192, 8192],
+            "pix_l": 1.5,
             "focal_l": 120.8,
             "aperture_d": 1.5,
             "wavelength": 550.0,

--- a/data/input/oneshot_itokawa_opengl.json
+++ b/data/input/oneshot_itokawa_opengl.json
@@ -30,19 +30,6 @@
         "device": "GPU",
         "tile_size": 256,
         "starcat_dir": "data/stardb/deep_space_objects.sqlite",
-        "brdf_params": 
-        {
-			"J": 0,
-			"th_p": 26,
-			"w": 0.31,
-			"b": -0.35,
-			"c": 0,
-			"B_SH0": 0.86,
-			"hs": 0.00021,
-			"B_CB0": 0,
-			"hc": 0.005,
-			"K": 1
-		},
         "sun": null,
         "lightref": null,
         "spacecraft": 
@@ -77,12 +64,24 @@
                 "file": "data/models/itokawa_f3145728.obj",
                 "name": "Itokawa"
             },
-            "albedo": 0.15,
-            "max_dim": 512
+            "max_dim": 512,
+            "brdf_params":
+            {
+                "J": 0,
+                "th_p": 26,
+                "w": 0.31,
+                "b": -0.35,
+                "c": 0,
+                "B_SH0": 0.86,
+                "hs": 0.00021,
+                "B_CB0": 0,
+                "hc": 0.005,
+                "K": 1
+            }
         },
         "instrument": 
         {
-            "res": [8192, 8192],
+            "res": [4096, 4096],
             "pix_l": 1.5,
             "focal_l": 120.8,
             "aperture_d": 1.5,

--- a/sispo/sim/opengl/rendergl.py
+++ b/sispo/sim/opengl/rendergl.py
@@ -205,7 +205,6 @@ class RenderObject(RenderAbstractObject):
             mx33 = np.asarray(mx44)[:3, :3]
             mx33 /= np.linalg.norm(mx33, axis=0)
             self.q = quaternion.from_rotation_matrix(mx33).conj()
-            print(str(self.q))
 
     def prepare(self, scene):
         self._check_params()
@@ -315,8 +314,6 @@ class RenderScene(RenderAbstractObject):
             for i, o in self._objs.values():
                 rel_pos_v[i] = tools.q_times_v(c.q.conj(), o.loc - c.loc)
                 rel_rot_q[i] = c.q.conj() * o.q
-
-            print('\n\ngf_cam_q, gf_ast_q: \n%s\n%s' % (c.q, o.q))
 
             # make sure correct order, correct scale
             rel_pos_v = [rel_pos_v[i]/self.object_scale for i in obj_idxs]
@@ -574,20 +571,13 @@ class RenderController:
             print('done')
         return obj
 
-    def load_coma(self, filename, dimensions, resolution, intensity, gf_ast_rot, scenes=None):
-
+    def load_coma(self, filename, dimensions, resolution, intensity, gf_ast_aa, scenes=None):
         if self.verbose:
             print('loading coma...', end='', flush=True)
 
         cell_size = dimensions[0] / resolution
-
-        icrf2gl_rot = Rotation(0.5, 0.5, -0.5, -0.5, False)
-        gf_ast_rot = gf_ast_rot.applyTo(icrf2gl_rot.revert())   # == icrf2gl_q.conj() * gf_ast_q
-        angle = gf_ast_rot.getAngle()
-        axis = np.array(gf_ast_rot.getAxis(RotationConvention.FRAME_TRANSFORM).toArray())
-        gf_ast_q = tools.angleaxis_to_q((angle, *axis))
-
-        gf_vx_cam_q = quaternion.one
+        gf_ast_q = tools.angleaxis_to_q(gf_ast_aa)
+        gf_vx_cam_q = np.quaternion(0.5, 0.5, -0.5, -0.5)
         lf_vx_ast_q = gf_vx_cam_q.conj() * gf_ast_q
 
         image = OpenEXR.InputFile(filename)

--- a/sispo/sim/sc.py
+++ b/sispo/sim/sc.py
@@ -164,7 +164,7 @@ class Instrument():
         # Kernel size calculated to equal skimage.filters.gaussian
         # Reference:
         # https://github.com/scipy/scipy/blob/4bfc152f6ee1ca48c73c06e27f7ef021d729f496/scipy/ndimage/filters.py#L214
-        kernel = int((4 * sigma + 0.5) * 2)
+        kernel = int(round(4 * float(sigma)) * 2 + 1)
         kernel = max(kernel, 5) # Don't use smaller than 5
         ksize = (kernel, kernel)
 

--- a/sispo/sim/sim.py
+++ b/sispo/sim/sim.py
@@ -248,14 +248,11 @@ class Environment():
                 coma.update(json.load(fh))
             assert self.opengl_renderer, '"coma" setting under "sssb" is currently only supported for opengl rendering'
             sssb_rot = coma.get('sssb_rot', False)
-            if sssb_rot:
-                icrf2gl_rot = Rotation(0.5, 0.5, -0.5, -0.5, False)
-                sc_icrf_rot = Rotation(Vector3D(sssb_rot[1:4]), sssb_rot[0], RotationConvention.FRAME_TRANSFORM)
-                sssb_rot = icrf2gl_rot.applyTo(sc_icrf_rot)
-            else:
+            if not sssb_rot:
                 # if param missing and one shot mode, assumes that coma is created with same asteroid orientation
                 assert self.sssb.rot_history, 'SSSB rotation state for cached coma is not given with "sssb_rot"'
                 sssb_rot = self.sssb.rot_history[0]
+                sssb_rot = (sssb_rot.getAngle(), *sssb_rot.getAxis(RotationConvention.FRAME_TRANSFORM).toArray())
 
             self.sssb.coma = self.renderer.load_coma(
                 coma['tiles_file'],

--- a/sispo/sim/sssb.py
+++ b/sispo/sim/sssb.py
@@ -75,4 +75,6 @@ class SmallSolarSystemBody(CelestialBody):
 
         # Create propagator
         self.propagator = KeplerianPropagator(self.trajectory, att_provider)
-        
+
+        # Loaded coma object, currently only used with OpenGL based rendering
+        self.coma = None


### PR DESCRIPTION
These changes make it possible to render comas when using the opengl rendering engine. At the moment voxel rendering happens in Python after OpenGL stuff. Thus, shadows are not taken into account. The coma must first be generated using the ComaCrator, then it can be loaded by adding e.g.
```
            "coma":
            {
                "file": "data/models/Jets--ROS_CAM1_20150710T074301.json",
                "intensity": 2e-6
            },
```
to the `sssb` section of an input file. The coma defining json file referenced is generated by the ComaCreator and is of form
```
{
  "dimensions": [40, 40, 40],
  "resolution": 600,
  "tiles_x": 25,
  "tiles_y": 25,
  "tiles_file": "data/models/Jets--ROS_CAM1_20150710T074301.exr"
}
```

I also moved the `brdf_params` reflectivity model parameters to be inside the `sssb` section instead of the `environment` section as it makes more sense that way.