### PR TITLE
Support Gaussian mixture models for the point-spread-function. Previo…

### DIFF
--- a/data/input/oneshot_itokawa.json
+++ b/data/input/oneshot_itokawa.json
@@ -89,7 +89,9 @@
             "aperture_d": 1.5,
             "wavelength": 550.0,
             "quantum_eff": 0.9,
-            "color_depth": 8
+            "color_depth": 12,
+            "psf_sigma": [[0.845, 0.7215], [0.155, 1.363]],
+            "ignore_shot_noise": true
         },
         "with_infobox": 0,
         "with_clipping": 1

--- a/data/input/oneshot_itokawa_opengl.json
+++ b/data/input/oneshot_itokawa_opengl.json
@@ -82,12 +82,14 @@
         "instrument": 
         {
             "res": [1024, 1024],
-            "pix_l": 12,
+            "pix_l": 12.0,
             "focal_l": 120.8,
             "aperture_d": 1.5,
             "wavelength": 550.0,
             "quantum_eff": 0.9,
-            "color_depth": 8
+            "color_depth": 12,
+            "psf_sigma": [[0.845, 0.7215], [0.155, 1.363]],
+            "ignore_shot_noise": true
         },
         "with_infobox": 0,
         "with_clipping": 1


### PR DESCRIPTION
Support Gaussian mixture models for the point-spread function (PSF). Previously, only a PSF based on diffraction was possible. If psf_sigma is not given at the instrument section of the input json file, the previous PSF is used by default. A mixure model for PSF can be specified by giving a list of tuples in the psf_sigma parameter. The first value in the tuple gives the weight and the second gives the standard deviation of the corresponding Gaussian distribution. The weights need to sum to one. The parameter psf_sigma can also be set to a single float, which is then interpreted as the sigma of a single Gaussian. If nothing is given, the sigma is calculated as before.

This work is related to revising the SISPO article based on reviewer comments. 
